### PR TITLE
Refactor/error properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ export const handler = async (event, context) => {
         data.line_number || null, // extract programmatically from stack trace
         data.col_number || null, // extract programmatically from stack trace
         data.project_id || null,
-        data.error.stack_trace || 'No stack trace available',
+        data.error.stack || 'No stack trace available',
         data.handled,
       ]
     );

--- a/mockData.js
+++ b/mockData.js
@@ -6,7 +6,7 @@ const mockEvent = {
       error: {
         name: 'MockError',
         message: 'A mock error occurred',
-        stack_trace: 'Mock stack trace',
+        stack: 'Mock stack trace',
       },
       handled: false,
       timestamp: new Date().toISOString(),


### PR DESCRIPTION
I refactored the expected error object of the incoming payload to have a property 'stack' instead of 'stack_trace', since the error objects in JavaScript come with a 'stack' property out of the box, and it seems unnecessary to perform extra logic to rename that property, when we can just expect a different property name. 